### PR TITLE
Admin Content CreationAlerts

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -16,6 +16,7 @@
 	<div class="row twelve columns">
 		<div class="six columns">
 			<h3>Create New Page</h3>
+			<div id="page-confirm"></div>
 			<hr />
 			<form id="new_page">
 				<label>Page Title</label>
@@ -41,6 +42,7 @@
 	<div class="row twelve columns">
 		<div class="six columns">
 			<h3>Create New Module</h3>
+			<div id="module-confirm"></div>
 			<hr />
 			<form id="new_module">
 				<label>Assign To Page</label>

--- a/css/admin.css
+++ b/css/admin.css
@@ -88,6 +88,26 @@ overflow: scroll;
     -webkit-animation-delay: 0.45s;
     animation-delay: 0.45s;
 }
+#page-confirm {
+	border-radius: 3px;
+	padding: 7px;
+	display: none;
+}
+#page-confirm-close {
+	float: right;
+    color: black;
+    text-decoration: none;
+}
+#module-confirm {
+	border-radius: 3px;
+	padding: 7px;
+	display: none;
+}
+#module-confirm-close {
+	float: right;
+    color: black;
+    text-decoration: none;
+}
 @-webkit-keyframes animIn {
     0% {
         -webkit-transform: translateX(-100px);

--- a/js/admin.js
+++ b/js/admin.js
@@ -20,14 +20,28 @@ jQuery(document).ready(function($){
         	data: {page_title : $('#page_title').val()},
         })
         .done(function(data) {
+			var confirm = document.getElementById("page-confirm");
+			confirm.style.backgroundColor = "#a0d3e8";
+			confirm.style.display = "block";
+			confirm.innerHTML = 'New page created successfully!<a href="#" id="page-confirm-close">x</a>';
+			document.getElementById("page-confirm-close").addEventListener("click", pageCloser);
         	console.log("new page created");
         })
         .fail(function() {
+			var confirm = document.getElementById("page-confirm");
+			confirm.style.backgroundColor = "#f08a24";
+			confirm.style.display = "block";
+			confirm.innerHTML = 'Error! New page not created.<a href="#" id="page-confirm-close">x</a>';
+			document.getElementById("page-confirm-close").addEventListener("click", pageCloser);
         	console.log("error, page creation failed");
         })
         .always(function() {
         	console.log("module page complete");
-        });  
+        });
+		function pageCloser() {
+			var confirm = document.getElementById("page-confirm");
+			confirm.style.display = "none";
+		}
     });
 
 	//create new module
@@ -39,14 +53,28 @@ jQuery(document).ready(function($){
         	data: {select_page : $('#select_page').val(), order : $('#order').val(), module_title : $('#module_title').val(), module_textarea : $('#module_textarea').val(), column_width : $('#column_width').val()},
         })
         .done(function(data) {
+			var modconfirm = document.getElementById("module-confirm");
+			modconfirm.style.backgroundColor = "#a0d3e8";
+			modconfirm.style.display = "block";
+			modconfirm.innerHTML = 'New module created successfully!<a href="#" id="module-confirm-close">x</a>';
+			document.getElementById("module-confirm-close").addEventListener("click", modCloser);
         	console.log("new module created");
         })
         .fail(function() {
+			var modconfirm = document.getElementById("module-confirm");
+			modconfirm.style.backgroundColor = "#f08a24";
+			modconfirm.style.display = "block";
+			modconfirm.innerHTML = 'Error! New module not created.<a href="#" id="module-confirm-close">x</a>';
+			document.getElementById("module-confirm-close").addEventListener("click", modCloser);
         	console.log("error, module creation failed");
         })
         .always(function() {
         	console.log("module creation complete");
-        });  
+        });
+		function modCloser() {
+			var confirm = document.getElementById("module-confirm");
+			confirm.style.display = "none";
+		}
     });
 
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -20,27 +20,24 @@ jQuery(document).ready(function($){
         	data: {page_title : $('#page_title').val()},
         })
         .done(function(data) {
-			var confirm = document.getElementById("page-confirm");
-			confirm.style.backgroundColor = "#a0d3e8";
-			confirm.style.display = "block";
-			confirm.innerHTML = 'New page created successfully!<a href="#" id="page-confirm-close">x</a>';
-			document.getElementById("page-confirm-close").addEventListener("click", pageCloser);
+			$("#page-confirm").css("background-color", "#a0d3e8");
+			$("#page-confirm").css("display", "block");
+			$("#page-confirm").html('New page created successfully!<a href="#" id="page-confirm-close">x</a>');
+			$("#page-confirm-close").bind("click", pageCloser);
         	console.log("new page created");
         })
         .fail(function() {
-			var confirm = document.getElementById("page-confirm");
-			confirm.style.backgroundColor = "#f08a24";
-			confirm.style.display = "block";
-			confirm.innerHTML = 'Error! New page not created.<a href="#" id="page-confirm-close">x</a>';
-			document.getElementById("page-confirm-close").addEventListener("click", pageCloser);
+			$("#page-confirm").css("background-color", "#f08a24");
+			$("#page-confirm").css("display", "block");
+			$("#page-confirm").html('Error! New page not created.<a href="#" id="page-confirm-close">x</a>');
+			$("#page-confirm-close").bind("click", pageCloser);
         	console.log("error, page creation failed");
         })
         .always(function() {
         	console.log("module page complete");
         });
 		function pageCloser() {
-			var confirm = document.getElementById("page-confirm");
-			confirm.style.display = "none";
+			$("#page-confirm").css("display", "none");
 		}
     });
 
@@ -53,27 +50,24 @@ jQuery(document).ready(function($){
         	data: {select_page : $('#select_page').val(), order : $('#order').val(), module_title : $('#module_title').val(), module_textarea : $('#module_textarea').val(), column_width : $('#column_width').val()},
         })
         .done(function(data) {
-			var modconfirm = document.getElementById("module-confirm");
-			modconfirm.style.backgroundColor = "#a0d3e8";
-			modconfirm.style.display = "block";
-			modconfirm.innerHTML = 'New module created successfully!<a href="#" id="module-confirm-close">x</a>';
-			document.getElementById("module-confirm-close").addEventListener("click", modCloser);
+			$("#module-confirm").css("background-color", "#a0d3e8");
+			$("#module-confirm").css("display", "block");
+			$("#module-confirm").html('New module created successfully!<a href="#" id="module-confirm-close">x</a>');
+			$("#module-confirm-close").bind("click", modCloser);
         	console.log("new module created");
         })
         .fail(function() {
-			var modconfirm = document.getElementById("module-confirm");
-			modconfirm.style.backgroundColor = "#f08a24";
-			modconfirm.style.display = "block";
-			modconfirm.innerHTML = 'Error! New module not created.<a href="#" id="module-confirm-close">x</a>';
-			document.getElementById("module-confirm-close").addEventListener("click", modCloser);
+			$("#module-confirm").css("background-color", "#f08a24");
+			$("#module-confirm").css("display", "block");
+			$("#module-confirm").html('Error! New module not created.<a href="#" id="module-confirm-close">x</a>');
+			$("#module-confirm-close").bind("click", modCloser);
         	console.log("error, module creation failed");
         })
         .always(function() {
         	console.log("module creation complete");
         });
 		function modCloser() {
-			var confirm = document.getElementById("module-confirm");
-			confirm.style.display = "none";
+			$("#module-confirm").css("display", "none");
 		}
     });
 


### PR DESCRIPTION
right now the only notices that content creation has completed or failed happens in a console message - which is not very helpful to users.

I've updated this to add a quick message for content create/fail.

Screenshot: http://monosnap.com/image/FFPkd9yfJ8IUfBM2KktCfnhekjeNMs
(yes I am up to 82 test pages, stop judging me ;) )